### PR TITLE
Adding getArray function to HydratedObject

### DIFF
--- a/json-api-rehydrate.js
+++ b/json-api-rehydrate.js
@@ -141,6 +141,15 @@
 		this.getOriginal = function(){
 			return original;
 		};
+		this.getArray = function() {
+			var arr = [];
+			for (var attribute in this) {
+				if (this.hasOwnProperty(attribute) && !isNaN(parseInt(attribute))) {
+					arr[parseInt(attribute)] = this[attribute];
+                }
+            }
+            return arr;
+        }
 	}
 
 	// Set prototype accessors

--- a/json-api-rehydrate.js
+++ b/json-api-rehydrate.js
@@ -146,10 +146,10 @@
 			for (var attribute in this) {
 				if (this.hasOwnProperty(attribute) && !isNaN(parseInt(attribute))) {
 					arr[parseInt(attribute)] = this[attribute];
-                }
-            }
-            return arr;
-        }
+				}
+			}
+			return arr;
+		}
 	}
 
 	// Set prototype accessors


### PR DESCRIPTION
Fixes an issue I've found with endpoints that produce arrays with additional properties. During rehydration, this becomes an object with numbered properties like:

```json
{
    "0": {...},
    "1": {...},
    "2": {...},
    "foo": "bar"
}
```

Each object will now provide a `getArray()` function which will find all numbered properties and return them in a real javascript Array object.

Usage would be:

```js
var data = jsonApiReHydrate.rehydrate(jsonResponse);
var dataArr = data.thing.getArray();
// Now array functions are available
dataArr.map((val) => transformer(val));
```